### PR TITLE
Remove build metadata when bumping Chart version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,9 @@ runs:
     - name: Automated Version Bump
       id: chart-version-bump
       run: |
-        version=$(pybump bump --file ${{ inputs.chart-path }}/Chart.yaml --level ${{ inputs.level }})
+        pybump bump --file ${{ inputs.chart-path }}/Chart.yaml --level ${{ inputs.level }}
+        semver=$(pybump get --file ${{ inputs.chart-path }}/Chart.yaml --sem-ver)
+        version=$(pybump set --file ${{ inputs.chart-path }}/Chart.yaml --set-version "$semver")
         echo "version=$version" >> $GITHUB_OUTPUT
         echo "CHART_VERSION=$version" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
Bumping major/minor/patch version should reset the build number back to 0